### PR TITLE
chore: add update script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:wasm": "npm run build && tree-sitter build-wasm",
     "start": "npm run build:wasm && tree-sitter web-ui",
     "test": "tree-sitter test",
+    "test:update": "tree-sitter test --update",
     "test:watch": "nodemon --ext ts,txt,fish,scm --watch grammar.ts --watch test --watch queries --exec 'npm run build && npm run test'",
     "test:examples": "bash ./scripts/test_shared.sh",
     "test:dev": "nodemon --ext fish --watch test.fish --watch grammar.ts --exec 'npm run build && tree-sitter parse ./test.fish -d'",


### PR DESCRIPTION
Adds a convenience `test:update` script to update snapshots. I would like to change this to be the default behavior for `test:watch` and maybe even `test`, but would have to have a separate script for ci such as `test:ci` as when updated it doesn't exit with a non-zero exit code. Would appreciate feedback here.
