### PR TITLE
ci: fail when build changes committed files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,10 @@ jobs:
             run: npm run test
           - name: Run parser against examples
             run: npm run test:examples
+          - name: Check for uncommitted changes
+            run: |
+              if ! git diff --exit-code; then
+                echo "Error: There are uncommitted changes after running tests"
+                echo "Please run 'npm run build' and commit the generated files"
+                exit 1
+              fi


### PR DESCRIPTION
Adds a check in ci to make sure that the generated files are up to date with the changed grammar file. Can also work in tandem with https://github.com/ram02z/tree-sitter-fish/pull/32 if desired.
