### PR TITLE
Highlight command options (arguments starting with `-`)

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -38,7 +38,11 @@
 "," @punctuation.delimiter
 
 (function_definition name: [(word) (concatenation)] @function)
+(function_definition option: (word) @constant (#match? @constant "^-."))
+(function_definition option: (concatenation . (word) @constant (#match? @constant "^-.")))
 (command name: (word) @function)
+(command argument: (word) @constant (#match? @constant "^-."))
+(command argument: (concatenation . (word) @constant (#match? @constant "^-.")))
 
 [
  "switch"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -43,6 +43,7 @@
 (command name: (word) @function)
 (command argument: (word) @constant (#match? @constant "^-."))
 (command argument: (concatenation . (word) @constant (#match? @constant "^-.")))
+(command_substitution) @embedded
 
 [
  "switch"


### PR DESCRIPTION
See discussion in #35.

Command arguments that begin with a hyphen and at least one more character are highlighted as `@constant`.

DISCLAIMER: this works fine in Zed but before merging somebody should double-check with nvim.